### PR TITLE
feat(master): Admin CRUD for Companies, Departments, Designations + U…

### DIFF
--- a/HRHub/HRHub.Web/Controllers/CompaniesController.cs
+++ b/HRHub/HRHub.Web/Controllers/CompaniesController.cs
@@ -1,0 +1,158 @@
+﻿using HRHub.Web.Data.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace HRHub.Web.Controllers
+{
+    [Authorize(Roles = "Admin")]
+    public class CompaniesController : Controller
+    {
+        private readonly HrHubContext _context;
+
+        public CompaniesController(HrHubContext context)
+        {
+            _context = context;
+        }
+
+        // GET: Companies
+        public async Task<IActionResult> Index()
+        {
+            return View(await _context.Companies.ToListAsync());
+        }
+
+        // GET: Companies/Details/5
+        public async Task<IActionResult> Details(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            var company = await _context.Companies
+                .FirstOrDefaultAsync(m => m.CompanyId == id);
+            if (company == null)
+            {
+                return NotFound();
+            }
+
+            return View(company);
+        }
+
+        // GET: Companies/Create
+        public IActionResult Create()
+        {
+            return View();
+        }
+
+        // POST: Companies/Create
+        // To protect from overposting attacks, enable the specific properties you want to bind to.
+        // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Create([Bind("CompanyId,Name")] Company company)
+        {
+            if (ModelState.IsValid)
+            {
+                _context.Add(company);
+                await _context.SaveChangesAsync();
+                return RedirectToAction(nameof(Index));
+            }
+            return View(company);
+        }
+
+        // GET: Companies/Edit/5
+        public async Task<IActionResult> Edit(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            var company = await _context.Companies.FindAsync(id);
+            if (company == null)
+            {
+                return NotFound();
+            }
+            return View(company);
+        }
+
+        // POST: Companies/Edit/5
+        // To protect from overposting attacks, enable the specific properties you want to bind to.
+        // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Edit(int id, [Bind("CompanyId,Name")] Company company)
+        {
+            if (id != company.CompanyId)
+            {
+                return NotFound();
+            }
+
+            if (ModelState.IsValid)
+            {
+                try
+                {
+                    _context.Update(company);
+                    await _context.SaveChangesAsync();
+                }
+                catch (DbUpdateConcurrencyException)
+                {
+                    if (!CompanyExists(company.CompanyId))
+                    {
+                        return NotFound();
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+                return RedirectToAction(nameof(Index));
+            }
+            return View(company);
+        }
+
+        // GET: Companies/Delete/5
+        public async Task<IActionResult> Delete(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            var company = await _context.Companies
+                .FirstOrDefaultAsync(m => m.CompanyId == id);
+            if (company == null)
+            {
+                return NotFound();
+            }
+
+            return View(company);
+        }
+
+        // POST: Companies/Delete/5
+        [HttpPost, ActionName("Delete")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeleteConfirmed(int id)
+        {
+            var company = await _context.Companies.FindAsync(id);
+            if (company != null)
+            {
+                _context.Companies.Remove(company);
+            }
+
+            await _context.SaveChangesAsync();
+            return RedirectToAction(nameof(Index));
+        }
+
+        private bool CompanyExists(int id)
+        {
+            return _context.Companies.Any(e => e.CompanyId == id);
+        }
+    }
+}

--- a/HRHub/HRHub.Web/Controllers/DepartmentsController.cs
+++ b/HRHub/HRHub.Web/Controllers/DepartmentsController.cs
@@ -1,0 +1,165 @@
+﻿using HRHub.Web.Data.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace HRHub.Web.Controllers
+{
+    [Authorize(Roles = "Admin")]
+    public class DepartmentsController : Controller
+    {
+        private readonly HrHubContext _context;
+        public DepartmentsController(HrHubContext context) => _context = context;
+
+        // GET: Departments
+        public async Task<IActionResult> Index()
+        {
+            var data = await _context.Departments
+                                     .Include(d => d.Company)
+                                     .AsNoTracking()
+                                     .ToListAsync();
+            return View(data);
+        }
+
+        // GET: Departments/Details/5
+        public async Task<IActionResult> Details(int? id)
+        {
+            if (id == null) return NotFound();
+
+            var department = await _context.Departments
+                                           .Include(d => d.Company)
+                                           .AsNoTracking()
+                                           .FirstOrDefaultAsync(m => m.DepartmentId == id);
+            if (department == null) return NotFound();
+
+            return View(department);
+        }
+
+        // GET: Departments/Create
+        public IActionResult Create()
+        {
+            ViewData["CompanyId"] = new SelectList(
+                _context.Companies.AsNoTracking(), "CompanyId", "Name"
+            );
+            return View();
+        }
+
+        // POST: Departments/Create
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Create([Bind("DepartmentId,CompanyId,Name")] Department department)
+        {
+            // nav-prop validation noise
+            ModelState.Remove(nameof(Department.Company));
+            ModelState.Remove("Company");
+
+            // FK exists check
+            if (!await _context.Companies.AnyAsync(c => c.CompanyId == department.CompanyId))
+                ModelState.AddModelError("CompanyId", "Please select a valid company.");
+
+            System.Diagnostics.Debug.WriteLine($"[POST-Create] CompanyId={department.CompanyId}, Name='{department.Name}'");
+
+            if (!ModelState.IsValid)
+            {
+                foreach (var e in ModelState.SelectMany(kv => kv.Value.Errors))
+                    System.Diagnostics.Debug.WriteLine("[ModelState] " + e.ErrorMessage);
+
+                ViewData["CompanyId"] = new SelectList(
+                    _context.Companies.AsNoTracking(), "CompanyId", "Name", department.CompanyId
+                );
+                return View(department);
+            }
+
+            _context.Add(department);
+            await _context.SaveChangesAsync();   // INSERT
+            return RedirectToAction(nameof(Index));
+        }
+
+        // GET: Departments/Edit/5
+        public async Task<IActionResult> Edit(int? id)
+        {
+            if (id == null) return NotFound();
+
+            var department = await _context.Departments.FindAsync(id);
+            if (department == null) return NotFound();
+
+            ViewData["CompanyId"] = new SelectList(
+                _context.Companies.AsNoTracking(), "CompanyId", "Name", department.CompanyId
+            );
+            return View(department);
+        }
+
+        // POST: Departments/Edit/5
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Edit(int id, [Bind("DepartmentId,CompanyId,Name")] Department department)
+        {
+            if (id != department.DepartmentId) return NotFound();
+
+            // nav-prop validation noise 
+            ModelState.Remove(nameof(Department.Company));
+            ModelState.Remove("Company");
+
+            // FK exists
+            if (!await _context.Companies.AnyAsync(c => c.CompanyId == department.CompanyId))
+                ModelState.AddModelError("CompanyId", "Please select a valid company.");
+
+            System.Diagnostics.Debug.WriteLine($"[POST-Edit] Id={id}, CompanyId={department.CompanyId}, Name='{department.Name}'");
+
+            if (!ModelState.IsValid)
+            {
+                foreach (var e in ModelState.SelectMany(kv => kv.Value.Errors))
+                    System.Diagnostics.Debug.WriteLine("[ModelState] " + e.ErrorMessage);
+
+                ViewData["CompanyId"] = new SelectList(
+                    _context.Companies.AsNoTracking(), "CompanyId", "Name", department.CompanyId
+                );
+                return View(department);
+            }
+
+            try
+            {
+                _context.Update(department);      // UPDATE
+                await _context.SaveChangesAsync();
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                var exists = await _context.Departments.AnyAsync(e => e.DepartmentId == id);
+                if (!exists) return NotFound();
+                throw;
+            }
+            return RedirectToAction(nameof(Index));
+        }
+
+        // GET: Departments/Delete/5
+        public async Task<IActionResult> Delete(int? id)
+        {
+            if (id == null) return NotFound();
+
+            var department = await _context.Departments
+                                           .Include(d => d.Company)
+                                           .AsNoTracking()
+                                           .FirstOrDefaultAsync(m => m.DepartmentId == id);
+            if (department == null) return NotFound();
+
+            return View(department);
+        }
+
+        // POST: Departments/Delete/5
+        [HttpPost, ActionName("Delete")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeleteConfirmed(int id)
+        {
+            var department = await _context.Departments.FindAsync(id);
+            if (department != null)
+            {
+                _context.Departments.Remove(department);
+                await _context.SaveChangesAsync();
+            }
+            return RedirectToAction(nameof(Index));
+        }
+    }
+}

--- a/HRHub/HRHub.Web/Controllers/DesignationsController.cs
+++ b/HRHub/HRHub.Web/Controllers/DesignationsController.cs
@@ -1,0 +1,158 @@
+﻿using HRHub.Web.Data.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace HRHub.Web.Controllers
+{
+    [Authorize(Roles = "Admin")]
+    public class DesignationsController : Controller
+    {
+        private readonly HrHubContext _context;
+
+        public DesignationsController(HrHubContext context)
+        {
+            _context = context;
+        }
+
+        // GET: Designations
+        public async Task<IActionResult> Index()
+        {
+            return View(await _context.Designations.ToListAsync());
+        }
+
+        // GET: Designations/Details/5
+        public async Task<IActionResult> Details(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            var designation = await _context.Designations
+                .FirstOrDefaultAsync(m => m.DesignationId == id);
+            if (designation == null)
+            {
+                return NotFound();
+            }
+
+            return View(designation);
+        }
+
+        // GET: Designations/Create
+        public IActionResult Create()
+        {
+            return View();
+        }
+
+        // POST: Designations/Create
+        // To protect from overposting attacks, enable the specific properties you want to bind to.
+        // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Create([Bind("DesignationId,Title,Grade")] Designation designation)
+        {
+            if (ModelState.IsValid)
+            {
+                _context.Add(designation);
+                await _context.SaveChangesAsync();
+                return RedirectToAction(nameof(Index));
+            }
+            return View(designation);
+        }
+
+        // GET: Designations/Edit/5
+        public async Task<IActionResult> Edit(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            var designation = await _context.Designations.FindAsync(id);
+            if (designation == null)
+            {
+                return NotFound();
+            }
+            return View(designation);
+        }
+
+        // POST: Designations/Edit/5
+        // To protect from overposting attacks, enable the specific properties you want to bind to.
+        // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Edit(int id, [Bind("DesignationId,Title,Grade")] Designation designation)
+        {
+            if (id != designation.DesignationId)
+            {
+                return NotFound();
+            }
+
+            if (ModelState.IsValid)
+            {
+                try
+                {
+                    _context.Update(designation);
+                    await _context.SaveChangesAsync();
+                }
+                catch (DbUpdateConcurrencyException)
+                {
+                    if (!DesignationExists(designation.DesignationId))
+                    {
+                        return NotFound();
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+                return RedirectToAction(nameof(Index));
+            }
+            return View(designation);
+        }
+
+        // GET: Designations/Delete/5
+        public async Task<IActionResult> Delete(int? id)
+        {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            var designation = await _context.Designations
+                .FirstOrDefaultAsync(m => m.DesignationId == id);
+            if (designation == null)
+            {
+                return NotFound();
+            }
+
+            return View(designation);
+        }
+
+        // POST: Designations/Delete/5
+        [HttpPost, ActionName("Delete")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeleteConfirmed(int id)
+        {
+            var designation = await _context.Designations.FindAsync(id);
+            if (designation != null)
+            {
+                _context.Designations.Remove(designation);
+            }
+
+            await _context.SaveChangesAsync();
+            return RedirectToAction(nameof(Index));
+        }
+
+        private bool DesignationExists(int id)
+        {
+            return _context.Designations.Any(e => e.DesignationId == id);
+        }
+    }
+}

--- a/HRHub/HRHub.Web/HRHub.Web.csproj
+++ b/HRHub/HRHub.Web/HRHub.Web.csproj
@@ -16,6 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.7" />
   </ItemGroup>
 
 </Project>

--- a/HRHub/HRHub.Web/Views/Companies/Create.cshtml
+++ b/HRHub/HRHub.Web/Views/Companies/Create.cshtml
@@ -1,0 +1,42 @@
+﻿@model HRHub.Web.Data.Models.Company
+@{
+    ViewData["Title"] = "Create Company";
+}
+<div class="container py-4">
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb mb-3">
+            <li class="breadcrumb-item"><a asp-action="Index">Companies</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Create</li>
+        </ol>
+    </nav>
+
+    <div class="card card-shadow col-lg-7">
+        <div class="card-header">
+            <strong>New Company</strong>
+        </div>
+        <div class="card-body">
+            <form asp-action="Create" method="post">
+                @Html.AntiForgeryToken()
+                <div asp-validation-summary="ModelOnly" class="alert alert-danger py-2"></div>
+
+                <div class="mb-3">
+                    <label asp-for="Name" class="form-label"></label>
+                    <input asp-for="Name" class="form-control" placeholder="e.g., Demo Company" />
+                    <span asp-validation-for="Name" class="text-danger"></span>
+                </div>
+
+                <div class="d-flex gap-2">
+                    <button type="submit" class="btn btn-primary">Save</button>
+                    <a asp-action="Index" class="btn btn-outline-secondary">Back</a>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    @{
+        await Html.RenderPartialAsync("_ValidationScriptsPartial");
+    }
+
+}

--- a/HRHub/HRHub.Web/Views/Companies/Delete.cshtml
+++ b/HRHub/HRHub.Web/Views/Companies/Delete.cshtml
@@ -1,0 +1,35 @@
+﻿@model HRHub.Web.Data.Models.Company
+@{
+    ViewData["Title"] = "Delete Company";
+}
+<div class="container py-4">
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb mb-3">
+            <li class="breadcrumb-item"><a asp-action="Index">Companies</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Delete</li>
+        </ol>
+    </nav>
+
+    <div class="alert alert-warning" role="alert">
+        <strong>Are you sure?</strong> This will permanently remove <em>@Model.Name</em>.
+    </div>
+
+    <div class="card card-shadow col-lg-7">
+        <div class="card-body">
+            <dl class="row mb-4">
+                <dt class="col-sm-4">Company ID</dt>
+                <dd class="col-sm-8">@Model.CompanyId</dd>
+
+                <dt class="col-sm-4">Name</dt>
+                <dd class="col-sm-8">@Model.Name</dd>
+            </dl>
+
+            <form asp-action="Delete" method="post" class="d-flex gap-2">
+                @Html.AntiForgeryToken()
+                <input type="hidden" asp-for="CompanyId" />
+                <button type="submit" class="btn btn-danger">Delete</button>
+                <a asp-action="Index" class="btn btn-outline-secondary">Cancel</a>
+            </form>
+        </div>
+    </div>
+</div>

--- a/HRHub/HRHub.Web/Views/Companies/Details.cshtml
+++ b/HRHub/HRHub.Web/Views/Companies/Details.cshtml
@@ -1,0 +1,31 @@
+﻿@model HRHub.Web.Data.Models.Company
+@{
+    ViewData["Title"] = "Company Details";
+}
+<div class="container py-4">
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb mb-3">
+            <li class="breadcrumb-item"><a asp-action="Index">Companies</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Details</li>
+        </ol>
+    </nav>
+
+    <div class="card card-shadow col-lg-7">
+        <div class="card-header">
+            <strong>@Model.Name</strong>
+        </div>
+        <div class="card-body">
+            <dl class="row mb-0">
+                <dt class="col-sm-4">Company ID</dt>
+                <dd class="col-sm-8">@Model.CompanyId</dd>
+
+                <dt class="col-sm-4">Name</dt>
+                <dd class="col-sm-8">@Model.Name</dd>
+            </dl>
+        </div>
+        <div class="card-footer d-flex gap-2">
+            <a asp-action="Edit" asp-route-id="@Model.CompanyId" class="btn btn-primary">Edit</a>
+            <a asp-action="Index" class="btn btn-outline-secondary">Back</a>
+        </div>
+    </div>
+</div>

--- a/HRHub/HRHub.Web/Views/Companies/Edit.cshtml
+++ b/HRHub/HRHub.Web/Views/Companies/Edit.cshtml
@@ -1,0 +1,45 @@
+﻿@model HRHub.Web.Data.Models.Company
+@{
+    ViewData["Title"] = "Edit Company";
+}
+<div class="container py-4">
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb mb-3">
+            <li class="breadcrumb-item"><a asp-action="Index">Companies</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Edit</li>
+        </ol>
+    </nav>
+
+    <div class="card card-shadow col-lg-7">
+        <div class="card-header d-flex justify-content-between">
+            <strong>Edit Company</strong>
+            <span class="text-muted">ID: @Model.CompanyId</span>
+        </div>
+        <div class="card-body">
+            <form asp-action="Edit" method="post">
+                @Html.AntiForgeryToken()
+                <div asp-validation-summary="ModelOnly" class="alert alert-danger py-2"></div>
+
+                <input type="hidden" asp-for="CompanyId" />
+
+                <div class="mb-3">
+                    <label asp-for="Name" class="form-label"></label>
+                    <input asp-for="Name" class="form-control" />
+                    <span asp-validation-for="Name" class="text-danger"></span>
+                </div>
+
+                <div class="d-flex gap-2">
+                    <button type="submit" class="btn btn-primary">Save</button>
+                    <a asp-action="Index" class="btn btn-outline-secondary">Back</a>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    @{
+        await Html.RenderPartialAsync("_ValidationScriptsPartial");
+    }
+
+}

--- a/HRHub/HRHub.Web/Views/Companies/Index.cshtml
+++ b/HRHub/HRHub.Web/Views/Companies/Index.cshtml
@@ -1,0 +1,43 @@
+﻿@model IEnumerable<HRHub.Web.Data.Models.Company>
+@{
+    ViewData["Title"] = "Companies";
+}
+<div class="container py-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h3 class="mb-0">Companies</h3>
+        <a asp-action="Create" class="btn btn-primary">+ Create</a>
+    </div>
+
+    @if (!Model.Any())
+    {
+        <div class="alert alert-info">No companies found.</div>
+    }
+    else
+    {
+        <div class="card card-shadow">
+            <div class="table-responsive">
+                <table class="table table-striped table-hover align-middle mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th>Name</th>
+                            <th class="text-end" style="width:220px;"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var item in Model)
+                        {
+                            <tr>
+                                <td>@item.Name</td>
+                                <td class="text-end">
+                                    <a asp-action="Details" asp-route-id="@item.CompanyId" class="btn btn-sm btn-outline-secondary">View</a>
+                                    <a asp-action="Edit" asp-route-id="@item.CompanyId" class="btn btn-sm btn-primary">Edit</a>
+                                    <a asp-action="Delete" asp-route-id="@item.CompanyId" class="btn btn-sm btn-danger">Delete</a>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    }
+</div>

--- a/HRHub/HRHub.Web/Views/Departments/Create.cshtml
+++ b/HRHub/HRHub.Web/Views/Departments/Create.cshtml
@@ -1,0 +1,50 @@
+﻿@model HRHub.Web.Data.Models.Department
+@{
+    ViewData["Title"] = "Create Department";
+}
+<div class="container py-4">
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb mb-3">
+            <li class="breadcrumb-item"><a asp-action="Index">Departments</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Create</li>
+        </ol>
+    </nav>
+
+    <div class="card card-shadow">
+        <div class="card-header">
+            <strong>New Department</strong>
+        </div>
+        <div class="card-body">
+            <form asp-action="Create" method="post">
+                @Html.AntiForgeryToken()
+                <div asp-validation-summary="ModelOnly" class="alert alert-danger py-2" role="alert"></div>
+
+                <div class="mb-3">
+                    <label asp-for="CompanyId" class="form-label"></label>
+                    <select asp-for="CompanyId" class="form-select" asp-items="ViewBag.CompanyId">
+                        <option value="">-- Select company --</option>
+                    </select>
+                    <span asp-validation-for="CompanyId" class="text-danger"></span>
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="Name" class="form-label"></label>
+                    <input asp-for="Name" class="form-control" placeholder="e.g., Marketing" />
+                    <span asp-validation-for="Name" class="text-danger"></span>
+                </div>
+
+                <div class="d-flex gap-2">
+                    <button type="submit" class="btn btn-primary">Create</button>
+                    <a asp-action="Index" class="btn btn-outline-secondary">Cancel</a>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    @{
+        await Html.RenderPartialAsync("_ValidationScriptsPartial");
+    }
+
+}

--- a/HRHub/HRHub.Web/Views/Departments/Delete.cshtml
+++ b/HRHub/HRHub.Web/Views/Departments/Delete.cshtml
@@ -1,0 +1,35 @@
+﻿@model HRHub.Web.Data.Models.Department
+@{
+    ViewData["Title"] = "Delete Department";
+}
+<div class="container py-4">
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb mb-3">
+            <li class="breadcrumb-item"><a asp-action="Index">Departments</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Delete</li>
+        </ol>
+    </nav>
+
+    <div class="alert alert-warning" role="alert">
+        <strong>Are you sure?</strong> This will permanently remove <em>@Model.Name</em>.
+    </div>
+
+    <div class="card card-shadow">
+        <div class="card-body">
+            <dl class="row mb-4">
+                <dt class="col-sm-3">Department ID</dt>
+                <dd class="col-sm-9">@Model.DepartmentId</dd>
+
+                <dt class="col-sm-3">Company</dt>
+                <dd class="col-sm-9">@Model.Company?.Name</dd>
+            </dl>
+
+            <form asp-action="Delete" method="post">
+                @Html.AntiForgeryToken()
+                <input type="hidden" asp-for="DepartmentId" />
+                <button type="submit" class="btn btn-danger">Delete</button>
+                <a asp-action="Index" class="btn btn-outline-secondary ms-2">Cancel</a>
+            </form>
+        </div>
+    </div>
+</div>

--- a/HRHub/HRHub.Web/Views/Departments/Details.cshtml
+++ b/HRHub/HRHub.Web/Views/Departments/Details.cshtml
@@ -1,0 +1,31 @@
+﻿@model HRHub.Web.Data.Models.Department
+@{
+    ViewData["Title"] = "Department Details";
+}
+<div class="container py-4">
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb mb-3">
+            <li class="breadcrumb-item"><a asp-action="Index">Departments</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Details</li>
+        </ol>
+    </nav>
+
+    <div class="card card-shadow">
+        <div class="card-header">
+            <strong>@Model.Name</strong>
+        </div>
+        <div class="card-body">
+            <dl class="row mb-0">
+                <dt class="col-sm-3">Department ID</dt>
+                <dd class="col-sm-9">@Model.DepartmentId</dd>
+
+                <dt class="col-sm-3">Company</dt>
+                <dd class="col-sm-9">@Model.Company?.Name</dd>
+            </dl>
+        </div>
+        <div class="card-footer d-flex gap-2">
+            <a asp-action="Edit" asp-route-id="@Model.DepartmentId" class="btn btn-primary">Edit</a>
+            <a asp-action="Index" class="btn btn-outline-secondary">Back</a>
+        </div>
+    </div>
+</div>

--- a/HRHub/HRHub.Web/Views/Departments/Edit.cshtml
+++ b/HRHub/HRHub.Web/Views/Departments/Edit.cshtml
@@ -1,0 +1,51 @@
+﻿@model HRHub.Web.Data.Models.Department
+@{
+    ViewData["Title"] = "Edit Department";
+}
+<div class="container py-4">
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb mb-3">
+            <li class="breadcrumb-item"><a asp-action="Index">Departments</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Edit</li>
+        </ol>
+    </nav>
+
+    <div class="card card-shadow">
+        <div class="card-header d-flex justify-content-between">
+            <strong>Edit Department</strong>
+            <span class="text-muted">ID: @Model.DepartmentId</span>
+        </div>
+        <div class="card-body">
+            <form asp-action="Edit" method="post">
+                @Html.AntiForgeryToken()
+                <div asp-validation-summary="ModelOnly" class="alert alert-danger py-2"></div>
+
+                <input type="hidden" asp-for="DepartmentId" />
+
+                <div class="mb-3">
+                    <label asp-for="CompanyId" class="form-label"></label>
+                    <select asp-for="CompanyId" class="form-select" asp-items="ViewBag.CompanyId"></select>
+                    <span asp-validation-for="CompanyId" class="text-danger"></span>
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="Name" class="form-label"></label>
+                    <input asp-for="Name" class="form-control" />
+                    <span asp-validation-for="Name" class="text-danger"></span>
+                </div>
+
+                <div class="d-flex gap-2">
+                    <button type="submit" class="btn btn-primary">Save</button>
+                    <a asp-action="Index" class="btn btn-outline-secondary">Back</a>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    @{
+        await Html.RenderPartialAsync("_ValidationScriptsPartial");
+    }
+
+}

--- a/HRHub/HRHub.Web/Views/Departments/Index.cshtml
+++ b/HRHub/HRHub.Web/Views/Departments/Index.cshtml
@@ -1,0 +1,40 @@
+﻿@model IEnumerable<HRHub.Web.Data.Models.Department>
+@{
+    ViewData["Title"] = "Departments";
+}
+<div class="container py-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h3 class="mb-0">Departments</h3>
+        <a asp-action="Create" class="btn btn-primary">
+            + Create
+        </a>
+    </div>
+
+    <div class="card card-shadow">
+        <div class="table-responsive">
+            <table class="table table-striped table-hover align-middle mb-0">
+                <thead class="table-light">
+                    <tr>
+                        <th style="width:40%">Department</th>
+                        <th style="width:40%">Company</th>
+                        <th class="text-end" style="width:20%"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var item in Model)
+                    {
+                        <tr>
+                            <td>@item.Name</td>
+                            <td>@item.Company?.Name</td>
+                            <td class="text-end">
+                                <a asp-action="Details" asp-route-id="@item.DepartmentId" class="btn btn-sm btn-outline-secondary">View</a>
+                                <a asp-action="Edit" asp-route-id="@item.DepartmentId" class="btn btn-sm btn-primary">Edit</a>
+                                <a asp-action="Delete" asp-route-id="@item.DepartmentId" class="btn btn-sm btn-danger">Delete</a>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/HRHub/HRHub.Web/Views/Designations/Create.cshtml
+++ b/HRHub/HRHub.Web/Views/Designations/Create.cshtml
@@ -1,0 +1,48 @@
+﻿@model HRHub.Web.Data.Models.Designation
+@{
+    ViewData["Title"] = "Create Designation";
+}
+<div class="container py-4">
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb mb-3">
+            <li class="breadcrumb-item"><a asp-action="Index">Designations</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Create</li>
+        </ol>
+    </nav>
+
+    <div class="card card-shadow col-lg-7">
+        <div class="card-header">
+            <strong>New Designation</strong>
+        </div>
+        <div class="card-body">
+            <form asp-action="Create" method="post">
+                @Html.AntiForgeryToken()
+                <div asp-validation-summary="ModelOnly" class="alert alert-danger py-2"></div>
+
+                <div class="mb-3">
+                    <label asp-for="Title" class="form-label"></label>
+                    <input asp-for="Title" class="form-control" placeholder="e.g., Senior Developer" />
+                    <span asp-validation-for="Title" class="text-danger"></span>
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="Grade" class="form-label"></label>
+                    <input asp-for="Grade" class="form-control" type="number" step="1" min="0" placeholder="e.g., 1" />
+                    <span asp-validation-for="Grade" class="text-danger"></span>
+                </div>
+
+                <div class="d-flex gap-2">
+                    <button type="submit" class="btn btn-primary">Save</button>
+                    <a asp-action="Index" class="btn btn-outline-secondary">Back</a>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    @{
+        await Html.RenderPartialAsync("_ValidationScriptsPartial");
+    }
+
+}

--- a/HRHub/HRHub.Web/Views/Designations/Delete.cshtml
+++ b/HRHub/HRHub.Web/Views/Designations/Delete.cshtml
@@ -1,0 +1,38 @@
+﻿@model HRHub.Web.Data.Models.Designation
+@{
+    ViewData["Title"] = "Delete Designation";
+}
+<div class="container py-4">
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb mb-3">
+            <li class="breadcrumb-item"><a asp-action="Index">Designations</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Delete</li>
+        </ol>
+    </nav>
+
+    <div class="alert alert-warning" role="alert">
+        <strong>Are you sure?</strong> This will permanently remove <em>@Model.Title</em>.
+    </div>
+
+    <div class="card card-shadow col-lg-7">
+        <div class="card-body">
+            <dl class="row mb-4">
+                <dt class="col-sm-4">Designation ID</dt>
+                <dd class="col-sm-8">@Model.DesignationId</dd>
+
+                <dt class="col-sm-4">Title</dt>
+                <dd class="col-sm-8">@Model.Title</dd>
+
+                <dt class="col-sm-4">Grade</dt>
+                <dd class="col-sm-8">@Model.Grade</dd>
+            </dl>
+
+            <form asp-action="Delete" method="post" class="d-flex gap-2">
+                @Html.AntiForgeryToken()
+                <input type="hidden" asp-for="DesignationId" />
+                <button type="submit" class="btn btn-danger">Delete</button>
+                <a asp-action="Index" class="btn btn-outline-secondary">Cancel</a>
+            </form>
+        </div>
+    </div>
+</div>

--- a/HRHub/HRHub.Web/Views/Designations/Details.cshtml
+++ b/HRHub/HRHub.Web/Views/Designations/Details.cshtml
@@ -1,0 +1,34 @@
+﻿@model HRHub.Web.Data.Models.Designation
+@{
+    ViewData["Title"] = "Designation Details";
+}
+<div class="container py-4">
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb mb-3">
+            <li class="breadcrumb-item"><a asp-action="Index">Designations</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Details</li>
+        </ol>
+    </nav>
+
+    <div class="card card-shadow col-lg-7">
+        <div class="card-header">
+            <strong>@Model.Title</strong>
+        </div>
+        <div class="card-body">
+            <dl class="row mb-0">
+                <dt class="col-sm-4">Designation ID</dt>
+                <dd class="col-sm-8">@Model.DesignationId</dd>
+
+                <dt class="col-sm-4">Title</dt>
+                <dd class="col-sm-8">@Model.Title</dd>
+
+                <dt class="col-sm-4">Grade</dt>
+                <dd class="col-sm-8">@Model.Grade</dd>
+            </dl>
+        </div>
+        <div class="card-footer d-flex gap-2">
+            <a asp-action="Edit" asp-route-id="@Model.DesignationId" class="btn btn-primary">Edit</a>
+            <a asp-action="Index" class="btn btn-outline-secondary">Back</a>
+        </div>
+    </div>
+</div>

--- a/HRHub/HRHub.Web/Views/Designations/Edit.cshtml
+++ b/HRHub/HRHub.Web/Views/Designations/Edit.cshtml
@@ -1,0 +1,51 @@
+﻿@model HRHub.Web.Data.Models.Designation
+@{
+    ViewData["Title"] = "Edit Designation";
+}
+<div class="container py-4">
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb mb-3">
+            <li class="breadcrumb-item"><a asp-action="Index">Designations</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Edit</li>
+        </ol>
+    </nav>
+
+    <div class="card card-shadow col-lg-7">
+        <div class="card-header d-flex justify-content-between">
+            <strong>Edit Designation</strong>
+            <span class="text-muted">ID: @Model.DesignationId</span>
+        </div>
+        <div class="card-body">
+            <form asp-action="Edit" method="post">
+                @Html.AntiForgeryToken()
+                <div asp-validation-summary="ModelOnly" class="alert alert-danger py-2"></div>
+
+                <input type="hidden" asp-for="DesignationId" />
+
+                <div class="mb-3">
+                    <label asp-for="Title" class="form-label"></label>
+                    <input asp-for="Title" class="form-control" />
+                    <span asp-validation-for="Title" class="text-danger"></span>
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="Grade" class="form-label"></label>
+                    <input asp-for="Grade" class="form-control" type="number" step="1" min="0" />
+                    <span asp-validation-for="Grade" class="text-danger"></span>
+                </div>
+
+                <div class="d-flex gap-2">
+                    <button type="submit" class="btn btn-primary">Save</button>
+                    <a asp-action="Index" class="btn btn-outline-secondary">Back</a>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    @{
+        await Html.RenderPartialAsync("_ValidationScriptsPartial");
+    }
+
+}

--- a/HRHub/HRHub.Web/Views/Designations/Index.cshtml
+++ b/HRHub/HRHub.Web/Views/Designations/Index.cshtml
@@ -1,0 +1,45 @@
+﻿@model IEnumerable<HRHub.Web.Data.Models.Designation>
+@{
+    ViewData["Title"] = "Designations";
+}
+<div class="container py-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h3 class="mb-0">Designations</h3>
+        <a asp-action="Create" class="btn btn-primary">+ Create</a>
+    </div>
+
+    @if (!Model.Any())
+    {
+        <div class="alert alert-info">No designations found.</div>
+    }
+    else
+    {
+        <div class="card card-shadow">
+            <div class="table-responsive">
+                <table class="table table-striped table-hover align-middle mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th>Title</th>
+                            <th style="width:120px;">Grade</th>
+                            <th class="text-end" style="width:220px;"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var item in Model)
+                        {
+                            <tr>
+                                <td>@item.Title</td>
+                                <td>@item.Grade</td>
+                                <td class="text-end">
+                                    <a asp-action="Details" asp-route-id="@item.DesignationId" class="btn btn-sm btn-outline-secondary">View</a>
+                                    <a asp-action="Edit" asp-route-id="@item.DesignationId" class="btn btn-sm btn-primary">Edit</a>
+                                    <a asp-action="Delete" asp-route-id="@item.DesignationId" class="btn btn-sm btn-danger">Delete</a>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    }
+</div>

--- a/HRHub/HRHub.Web/Views/Shared/_Layout.cshtml
+++ b/HRHub/HRHub.Web/Views/Shared/_Layout.cshtml
@@ -25,6 +25,20 @@
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
                         </li>
+                        @if (User.IsInRole("Admin"))
+                        {
+                            <li class="nav-item">
+                                <a class="nav-link" asp-controller="Companies" asp-action="Index">Companies</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link" asp-controller="Departments" asp-action="Index">Departments</a>
+                            </li>
+                            <li class="nav-item">
+                                <a class="nav-link" asp-controller="Designations" asp-action="Index">Designations</a>
+                            </li>
+                        }
+
+
                     </ul>
                     <partial name="_LoginPartial" />
                 </div>

--- a/HRHub/HRHub.Web/Views/_ViewImports.cshtml
+++ b/HRHub/HRHub.Web/Views/_ViewImports.cshtml
@@ -1,3 +1,4 @@
 ﻿@using HRHub.Web
 @using HRHub.Web.Models
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+

--- a/HRHub/HRHub.Web/wwwroot/css/site.css
+++ b/HRHub/HRHub.Web/wwwroot/css/site.css
@@ -20,3 +20,11 @@ html {
 body {
   margin-bottom: 60px;
 }
+.card-shadow {
+    box-shadow: 0 6px 18px rgba(0,0,0,.06);
+    border-radius: .75rem;
+}
+
+.table thead th {
+    white-space: nowrap;
+}


### PR DESCRIPTION

- Scaffolded Admin CRUD for Companies, Departments, Designations (HrHubContext)
- Departments: company dropdown + FK validation (no textbox), re-populate on invalid
- Views: Bootstrap cards, breadcrumbs, clean tables, validation messages, antiforgery tokens
- Admin-only authorization on controllers; admin nav links added to _Layout


- Completes master data layer used by Employees, Attendance, and Leave modules

How to test
1) /Companies → Create/Edit/Delete a company
2) /Designations → Create/Edit/Delete (Grade numeric)
3) /Departments → Create (select a company from dropdown), Edit, Delete
4) Non-admin access blocked (Authorize guards)
5) Output (ASP.NET Core Web Server) shows INSERT/UPDATE on submit

