### PR TITLE
feat(attendance): My check-in/out + Admin report with auto-link (emai…

### DIFF
--- a/HRHub/HRHub.Web/Controllers/AttendanceController.cs
+++ b/HRHub/HRHub.Web/Controllers/AttendanceController.cs
@@ -1,0 +1,242 @@
+﻿using HRHub.Web.Data.Models;
+using HRHub.Web.Models.ViewModels;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HRHub.Web.Controllers
+{
+    /// <summary>
+    /// Attendance:
+    /// - My: first visit auto-links Identity user -> Employee by email, then renders status/actions
+    /// - AdminReport: consolidated admin view (date or month)
+    /// Uses EF Core 8 DateOnly/TimeOnly and DbSet Attendances.
+    /// </summary>
+    [Authorize]
+    public class AttendanceController : Controller
+    {
+        private readonly HrHubContext _db;
+        private readonly UserManager<IdentityUser> _userManager;
+        private readonly RoleManager<IdentityRole> _roleManager;
+        private readonly SignInManager<IdentityUser> _signInManager;
+
+        public AttendanceController(
+            HrHubContext db,
+            UserManager<IdentityUser> userManager,
+            RoleManager<IdentityRole> roleManager,
+            SignInManager<IdentityUser> signInManager)
+        {
+            _db = db;
+            _userManager = userManager;
+            _roleManager = roleManager;
+            _signInManager = signInManager;
+        }
+
+        /// <summary>Ensure current Identity user is linked to an Employee by matching Email; also ensure "Employee" role and refresh cookie.</summary>
+        private async Task<Employee?> EnsureLinkCurrentUserAsync()
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null) return null;
+
+            // Already linked?
+            var linked = await _db.Employees.FirstOrDefaultAsync(e => e.AspNetUserId == user.Id);
+            if (linked != null)
+            {
+                await EnsureEmployeeRoleAsync(user);
+                return linked;
+            }
+
+            // Match by email (case-insensitive)
+            var email = await _userManager.GetEmailAsync(user);
+            if (string.IsNullOrWhiteSpace(email)) return null;
+
+            var candidate = await _db.Employees
+                .FirstOrDefaultAsync(e => e.AspNetUserId == null &&
+                                          e.Email != null &&
+                                          e.Email.ToLower() == email.ToLower());
+            if (candidate == null) return null;
+
+            candidate.AspNetUserId = user.Id;
+            await _db.SaveChangesAsync();
+
+            await EnsureEmployeeRoleAsync(user);
+            return candidate;
+        }
+
+        /// <summary>Create "Employee" role if missing, add to user if missing, then refresh sign-in so role claim is live.</summary>
+        private async Task EnsureEmployeeRoleAsync(IdentityUser user)
+        {
+            if (!await _roleManager.RoleExistsAsync("Employee"))
+                await _roleManager.CreateAsync(new IdentityRole("Employee"));
+
+            if (!await _userManager.IsInRoleAsync(user, "Employee"))
+                await _userManager.AddToRoleAsync(user, "Employee");
+
+            await _signInManager.RefreshSignInAsync(user);
+        }
+
+        /// <summary>Resolve linked employee; if not linked yet, auto-link by email.</summary>
+        private async Task<Employee?> GetOrLinkCurrentEmployeeAsync()
+        {
+            var uid = _userManager.GetUserId(User);
+            if (!string.IsNullOrWhiteSpace(uid))
+            {
+                var e = await _db.Employees.AsNoTracking()
+                           .FirstOrDefaultAsync(x => x.AspNetUserId == uid);
+                if (e != null) return e;
+            }
+            return await EnsureLinkCurrentUserAsync();
+        }
+
+        /// <summary>
+        /// Employee dashboard for today. NO role requirement here so that first visit can auto-link.
+        /// </summary>
+        [Authorize] // <-- allow first visit without role; CheckIn/Out are role-guarded
+        [HttpGet]
+        public async Task<IActionResult> My()
+        {
+            var emp = await GetOrLinkCurrentEmployeeAsync();
+            if (emp == null)
+            {
+                // Auto-link failed: show guidance with current AspNetUserId
+                return View("MyMissing", _userManager.GetUserId(User));
+            }
+
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            var row = await _db.Attendances.AsNoTracking()
+                .FirstOrDefaultAsync(a => a.EmployeeId == emp.EmployeeId && a.Date == today);
+
+            var vm = new AttendanceMyVM
+            {
+                EmployeeId = emp.EmployeeId,
+                EmployeeName = emp.FullName,
+                Date = today,
+                InTime = row?.InTime,
+                OutTime = row?.OutTime,
+                Message = row == null
+                                ? "Not checked in yet."
+                                : row.OutTime == null
+                                    ? $"Checked in at {row.InTime}"
+                                    : $"Checked out at {row.OutTime}"
+            };
+            return View(vm);
+        }
+
+        /// <summary>Record check-in for today (Employee-only).</summary>
+        [Authorize(Roles = "Employee")]
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> CheckIn()
+        {
+            var emp = await GetOrLinkCurrentEmployeeAsync();
+            if (emp == null) return Unauthorized();
+
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            var now = TimeOnly.FromDateTime(DateTime.Now);
+
+            var existing = await _db.Attendances
+                .FirstOrDefaultAsync(a => a.EmployeeId == emp.EmployeeId && a.Date == today);
+
+            if (existing != null && existing.InTime.HasValue)
+            {
+                TempData["Err"] = "Already checked in.";
+                return RedirectToAction(nameof(My));
+            }
+
+            if (existing == null)
+            {
+                _db.Attendances.Add(new Attendance
+                {
+                    EmployeeId = emp.EmployeeId,
+                    Date = today,
+                    InTime = now
+                });
+            }
+            else
+            {
+                existing.InTime = now;
+                _db.Attendances.Update(existing);
+            }
+
+            await _db.SaveChangesAsync();
+            TempData["Ok"] = "Checked in successfully.";
+            return RedirectToAction(nameof(My));
+        }
+
+        /// <summary>Record check-out for today; validates OutTime > InTime (Employee-only).</summary>
+        [Authorize(Roles = "Employee")]
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> CheckOut()
+        {
+            var emp = await GetOrLinkCurrentEmployeeAsync();
+            if (emp == null) return Unauthorized();
+
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            var now = TimeOnly.FromDateTime(DateTime.Now);
+
+            var row = await _db.Attendances
+                .FirstOrDefaultAsync(a => a.EmployeeId == emp.EmployeeId && a.Date == today);
+
+            if (row == null || !row.InTime.HasValue)
+            {
+                TempData["Err"] = "Please check in first.";
+                return RedirectToAction(nameof(My));
+            }
+            if (row.OutTime.HasValue)
+            {
+                TempData["Err"] = "Already checked out.";
+                return RedirectToAction(nameof(My));
+            }
+            if (now <= row.InTime.Value)
+            {
+                TempData["Err"] = "Out time must be greater than in time.";
+                return RedirectToAction(nameof(My));
+            }
+
+            row.OutTime = now;
+            _db.Attendances.Update(row);
+            await _db.SaveChangesAsync();
+
+            TempData["Ok"] = "Checked out successfully.";
+            return RedirectToAction(nameof(My));
+        }
+
+        /// <summary>Admin-only consolidated report with date or month filters.</summary>
+        [Authorize(Roles = "Admin")]
+        [HttpGet]
+        public async Task<IActionResult> AdminReport(DateOnly? date, int? year, int? month)
+        {
+            var q = _db.Attendances
+                .Include(a => a.Employee)
+                .AsNoTracking()
+                .AsQueryable();
+
+            if (date.HasValue)
+                q = q.Where(a => a.Date == date.Value);
+            else if (year.HasValue && month.HasValue)
+                q = q.Where(a => a.Date.Year == year.Value && a.Date.Month == month.Value);
+
+            var rows = await q
+                .OrderBy(a => a.Date).ThenBy(a => a.Employee.FullName)
+                .Select(a => new AttendanceRowVM
+                {
+                    Employee = a.Employee.FullName,
+                    Date = a.Date,
+                    InTime = a.InTime,
+                    OutTime = a.OutTime
+                })
+                .ToListAsync();
+
+            var vm = new AttendanceReportVM
+            {
+                Date = date,
+                Year = year,
+                Month = month,
+                Rows = rows
+            };
+            return View(vm);
+        }
+    }
+}

--- a/HRHub/HRHub.Web/Models/ViewModels/AttendanceMyVM.cs
+++ b/HRHub/HRHub.Web/Models/ViewModels/AttendanceMyVM.cs
@@ -1,0 +1,14 @@
+﻿namespace HRHub.Web.Models.ViewModels
+{
+    /// <summary>View model for the "My Attendance" page.</summary>
+    public class AttendanceMyVM
+    {
+        public int EmployeeId { get; set; }
+        public string EmployeeName { get; set; } = "";
+        public DateOnly Date { get; set; }
+        public TimeOnly? InTime { get; set; }
+        public TimeOnly? OutTime { get; set; }
+        public bool HasRow => InTime.HasValue || OutTime.HasValue;
+        public string? Message { get; set; }
+    }
+}

--- a/HRHub/HRHub.Web/Models/ViewModels/AttendanceReportVM.cs
+++ b/HRHub/HRHub.Web/Models/ViewModels/AttendanceReportVM.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+
+namespace HRHub.Web.Models.ViewModels
+{
+    /// <summary>Single row for the admin report.</summary>
+    public class AttendanceRowVM
+    {
+        public string Employee { get; set; } = "";
+        public DateOnly Date { get; set; }
+        public TimeOnly? InTime { get; set; }
+        public TimeOnly? OutTime { get; set; }
+    }
+
+    /// <summary>Filter + results for admin attendance report.</summary>
+    public class AttendanceReportVM
+    {
+        public DateOnly? Date { get; set; }
+        public int? Year { get; set; }
+        public int? Month { get; set; }
+        public List<AttendanceRowVM> Rows { get; set; } = new();
+    }
+}

--- a/HRHub/HRHub.Web/Views/Attendance/AdminReport.cshtml
+++ b/HRHub/HRHub.Web/Views/Attendance/AdminReport.cshtml
@@ -1,0 +1,60 @@
+﻿@model HRHub.Web.Models.ViewModels.AttendanceReportVM
+@{
+    ViewData["Title"] = "Attendance Report";
+    var d = Model.Date?.ToString("yyyy-MM-dd") ?? "";
+    var ym = (Model.Year.HasValue && Model.Month.HasValue) ? $"{Model.Year:0000}-{Model.Month:00}" : "";
+}
+<div class="container py-4">
+    <h3 class="mb-3">Attendance Report</h3>
+
+    <form method="get" class="row g-2 mb-3">
+        <div class="col-auto">
+            <label class="form-label">Date</label>
+            <input type="date" name="date" value="@d" class="form-control" />
+        </div>
+        <div class="col-auto align-self-end">
+            <button type="submit" class="btn btn-outline-secondary">Filter by Date</button>
+        </div>
+
+        <div class="w-100"></div>
+
+        <div class="col-auto">
+            <label class="form-label">Month</label>
+            <input type="month" class="form-control"
+                   value="@ym"
+                   onchange="const v=this.value.split('-'); this.form.year.value=v[0]; this.form.month.value=v[1];" />
+            <input type="hidden" name="year" value="@(Model.Year?.ToString() ?? "")" />
+            <input type="hidden" name="month" value="@(Model.Month?.ToString() ?? "")" />
+        </div>
+        <div class="col-auto align-self-end">
+            <button type="submit" class="btn btn-outline-secondary">Filter by Month</button>
+            <a asp-action="AdminReport" class="btn btn-link">Reset</a>
+        </div>
+    </form>
+
+    <div class="card card-shadow">
+        <div class="table-responsive">
+            <table class="table table-striped table-hover align-middle mb-0">
+                <thead class="table-light">
+                    <tr>
+                        <th>Date</th>
+                        <th>Employee</th>
+                        <th>In</th>
+                        <th>Out</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var r in Model.Rows)
+                    {
+                        <tr>
+                            <td>@r.Date.ToString("yyyy-MM-dd")</td>
+                            <td>@r.Employee</td>
+                            <td>@(r.InTime?.ToString() ?? "-")</td>
+                            <td>@(r.OutTime?.ToString() ?? "-")</td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/HRHub/HRHub.Web/Views/Attendance/My.cshtml
+++ b/HRHub/HRHub.Web/Views/Attendance/My.cshtml
@@ -1,0 +1,57 @@
+﻿@model HRHub.Web.Models.ViewModels.AttendanceMyVM
+@{
+    ViewData["Title"] = "My Attendance";
+}
+<div class="container py-4">
+    <h3 class="mb-3">My Attendance</h3>
+
+    @if (TempData["Ok"] != null)
+    {
+        <div class="alert alert-success">@TempData["Ok"]</div>
+    }
+    @if (TempData["Err"] != null)
+    {
+        <div class="alert alert-danger">@TempData["Err"]</div>
+    }
+
+    <div class="card card-shadow col-lg-7">
+        <div class="card-body">
+            <p class="mb-1"><strong>Employee:</strong> @Model.EmployeeName</p>
+            <p class="mb-1"><strong>Date:</strong> @Model.Date.ToString("yyyy-MM-dd")</p>
+            <p class="mb-3">
+                <strong>Status:</strong>
+                @if (!Model.InTime.HasValue)
+                {
+                    <span>Not checked in</span>
+                    ;
+                }
+                else if (Model.OutTime is null)
+                {
+
+                    <span>Checked in at @Model.InTime</span>
+                    ;
+                }
+                else
+                {
+
+                    <span>Checked out at @Model.OutTime</span>
+                    ;
+                }
+            </p>
+
+            <div class="d-flex gap-2">
+                <form asp-action="CheckIn" method="post">
+                    @Html.AntiForgeryToken()
+                    <button type="submit" class="btn btn-primary" @(Model.InTime.HasValue ? "disabled" : "")>Check in</button>
+                </form>
+                <form asp-action="CheckOut" method="post">
+                    @Html.AntiForgeryToken()
+                    <button type="submit" class="btn btn-outline-secondary"
+                            @((!Model.InTime.HasValue || Model.OutTime.HasValue) ? "disabled" : "")>
+                        Check out
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/HRHub/HRHub.Web/Views/Attendance/MyMissing.cshtml
+++ b/HRHub/HRHub.Web/Views/Attendance/MyMissing.cshtml
@@ -1,0 +1,10 @@
+﻿@model string
+@{
+    ViewData["Title"] = "My Attendance";
+}
+<div class="container py-4">
+    <div class="alert alert-warning">
+        No employee is linked to your account (AspNetUserId: <code>@Model</code>).<br />
+        Please ask an administrator to link your user to an Employee record.
+    </div>
+</div>

--- a/HRHub/HRHub.Web/Views/Shared/_Layout.cshtml
+++ b/HRHub/HRHub.Web/Views/Shared/_Layout.cshtml
@@ -34,8 +34,15 @@
 
                             <!-- add -->
                         }
+                        @if (User.Identity?.IsAuthenticated ?? false)
+                        {
+                            <li class="nav-item"><a class="nav-link" asp-controller="Attendance" asp-action="My">My Attendance</a></li>
+                        }
+                        @if (User.IsInRole("Admin"))
+                        {
+                            <li class="nav-item"><a class="nav-link" asp-controller="Attendance" asp-action="AdminReport">Attendance Report</a></li>
+                        }
 
-                       
 
 
                     </ul>


### PR DESCRIPTION

- Implemented "My Attendance" for employees: check-in / check-out
- Auto-link Identity user -> Employee on first visit by matching Email
- Ensures "Employee" role (creates if missing) and refreshes sign-in
- Admin-only "Attendance Report" with date or (year, month) filters
- EF Core 8 types: DateOnly/TimeOnly; uses DbSet<Attendance> Attendances
- Role-gated actions: My/CheckIn/CheckOut = Employee, AdminReport = Admin
- Navbar links added (My Attendance, Attendance Report)
- TempData-driven success/error messages and clean Bootstrap UI

Why
- Completes core attendance workflow with minimal friction:
  employees self-register and get activated automatically (by email match)

How to test
1) Admin creates Employee records (with correct Email)
2) Employee registers/logs in → open /Attendance/My
   - first visit auto-links user to Employee and assigns "Employee" role
   - Check in → Check out (same day)
3) Admin opens /Attendance/AdminReport?date=YYYY-MM-DD → sees rows
4) Attempt second check-in/out same day → friendly error message

Notes
- Enforced one-entry-per-day (UNIQUE(EmployeeId, Date)); OutTime > InTime (server + optional DB CHECK)
- Auto-link requires Employee.Email == Identity.Email (case-insensitive)
- Optional: block inactive employees and format times as hh:mm tt
