### PR TITLE
feat(promotion): Admin create promotion with rules and history

### DIFF
--- a/HRHub/HRHub.Web/Controllers/PromotionsController.cs
+++ b/HRHub/HRHub.Web/Controllers/PromotionsController.cs
@@ -1,0 +1,110 @@
+﻿using HRHub.Web.Data.Models;
+using HRHub.Web.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+
+namespace HRHub.Web.Controllers
+{
+    /// <summary>Admin-only: Create promotion + History</summary>
+    [Authorize(Roles = "Admin")]
+    public class PromotionsController : Controller
+    {
+        private readonly HrHubContext _db;
+        private readonly PromotionService _service;
+
+        public PromotionsController(HrHubContext db, PromotionService service)
+        {
+            _db = db;
+            _service = service;
+        }
+
+        // GET: /Promotions/Create?employeeId=1
+        [HttpGet]
+        public async Task<IActionResult> Create(int employeeId)
+        {
+            var emp = await _db.Employees
+                .Include(e => e.Designation)
+                .AsNoTracking()
+                .FirstOrDefaultAsync(e => e.EmployeeId == employeeId);
+            if (emp == null) return NotFound();
+
+            ViewData["NewDesignationId"] = new SelectList(
+                await _db.Designations.AsNoTracking().ToListAsync(),
+                "DesignationId", "Title", emp.DesignationId);
+
+            var vm = new Promotion
+            {
+                EmployeeId = emp.EmployeeId,
+                OldDesignationId = emp.DesignationId,
+                EffectiveDate = DateOnly.FromDateTime(DateTime.Today)
+            };
+            ViewData["EmployeeName"] = emp.FullName;
+            ViewData["OldDesignationTitle"] = (await _db.Designations.FindAsync(emp.DesignationId))?.Title ?? "";
+            return View(vm);
+        }
+
+        // POST: /Promotions/Create
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Create([Bind("EmployeeId,OldDesignationId,NewDesignationId,EffectiveDate,Notes")] Promotion vm)
+        {
+            var (ok, error, _) = await _service.ValidateAsync(vm.EmployeeId, vm.OldDesignationId, vm.NewDesignationId, vm.EffectiveDate);
+            if (!ok)
+            {
+                ModelState.AddModelError(string.Empty, error ?? "Validation failed.");
+                ViewData["NewDesignationId"] = new SelectList(
+                    await _db.Designations.AsNoTracking().ToListAsync(),
+                    "DesignationId", "Title", vm.NewDesignationId);
+
+                var empHdr = await _db.Employees.AsNoTracking().FirstOrDefaultAsync(e => e.EmployeeId == vm.EmployeeId);
+                ViewData["EmployeeName"] = empHdr?.FullName ?? "";
+                ViewData["OldDesignationTitle"] = (await _db.Designations.FindAsync(vm.OldDesignationId))?.Title ?? "";
+                return View(vm);
+            }
+
+            // Save promotion + update employee designation in a transaction
+            using var tx = await _db.Database.BeginTransactionAsync();
+            try
+            {
+                _db.Promotions.Add(vm);
+                await _db.SaveChangesAsync();
+
+                var emp = await _db.Employees.FirstAsync(e => e.EmployeeId == vm.EmployeeId);
+                emp.DesignationId = vm.NewDesignationId;
+                _db.Employees.Update(emp);
+                await _db.SaveChangesAsync();
+
+                await tx.CommitAsync();
+            }
+            catch
+            {
+                await tx.RollbackAsync();
+                throw;
+            }
+
+            TempData["Ok"] = "Promotion saved and employee designation updated.";
+            return RedirectToAction("Details", "Employees", new { id = vm.EmployeeId });
+        }
+
+        // GET: /Promotions/History/1  (id = EmployeeId)
+        [HttpGet]
+        public async Task<IActionResult> History(int id)
+        {
+            var emp = await _db.Employees.AsNoTracking().FirstOrDefaultAsync(e => e.EmployeeId == id);
+            if (emp == null) return NotFound();
+
+            var rows = await _db.Promotions
+                .Include(p => p.OldDesignation)
+                .Include(p => p.NewDesignation)
+                .Where(p => p.EmployeeId == id)
+                .OrderByDescending(p => p.EffectiveDate)
+                .AsNoTracking()
+                .ToListAsync();
+
+            ViewData["EmployeeName"] = emp.FullName;
+            return View(rows);
+        }
+    }
+}

--- a/HRHub/HRHub.Web/Data/Models/HrHubContext.cs
+++ b/HRHub/HRHub.Web/Data/Models/HrHubContext.cs
@@ -6,38 +6,31 @@ namespace HRHub.Web.Data.Models;
 
 public partial class HrHubContext : DbContext
 {
-    public HrHubContext()
-    {
-    }
+    public HrHubContext() { }
 
-    public HrHubContext(DbContextOptions<HrHubContext> options)
-        : base(options)
-    {
-    }
+    public HrHubContext(DbContextOptions<HrHubContext> options) : base(options) { }
 
     public virtual DbSet<Attendance> Attendances { get; set; }
-
     public virtual DbSet<Company> Companies { get; set; }
-
     public virtual DbSet<Department> Departments { get; set; }
-
     public virtual DbSet<Designation> Designations { get; set; }
-
     public virtual DbSet<Employee> Employees { get; set; }
-
     public virtual DbSet<Leaf> Leaves { get; set; }
-
     public virtual DbSet<LeaveType> LeaveTypes { get; set; }
+
+    // NEW: DbSet for Promotions
+ 
+    public virtual DbSet<Promotion> Promotions { get; set; } = null!;
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         => optionsBuilder.UseSqlServer("Name=ConnectionStrings:HrHubConnection");
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
+        // --- Attendance ---
         modelBuilder.Entity<Attendance>(entity =>
         {
             entity.HasKey(e => e.AttendanceId).HasName("PK__Attendan__8B69261C26F7EE3C");
-
             entity.ToTable("Attendance");
 
             entity.HasIndex(e => new { e.EmployeeId, e.Date }, "UQ_Attendance").IsUnique();
@@ -48,17 +41,17 @@ public partial class HrHubContext : DbContext
                 .HasConstraintName("FK_Attendance_Employees");
         });
 
+        // --- Company ---
         modelBuilder.Entity<Company>(entity =>
         {
             entity.HasKey(e => e.CompanyId).HasName("PK__Companie__2D971CACF07EB359");
-
             entity.Property(e => e.Name).HasMaxLength(100);
         });
 
+        // --- Department ---
         modelBuilder.Entity<Department>(entity =>
         {
             entity.HasKey(e => e.DepartmentId).HasName("PK__Departme__B2079BED6AC5C720");
-
             entity.Property(e => e.Name).HasMaxLength(100);
 
             entity.HasOne(d => d.Company).WithMany(p => p.Departments)
@@ -67,19 +60,19 @@ public partial class HrHubContext : DbContext
                 .HasConstraintName("FK_Departments_Companies");
         });
 
+        // --- Designation ---
         modelBuilder.Entity<Designation>(entity =>
         {
             entity.HasKey(e => e.DesignationId).HasName("PK__Designat__BABD60DE04591811");
-
             entity.Property(e => e.Title).HasMaxLength(100);
         });
 
+        // --- Employee ---
         modelBuilder.Entity<Employee>(entity =>
         {
             entity.HasKey(e => e.EmployeeId).HasName("PK__Employee__7AD04F11D413D973");
 
             entity.HasIndex(e => e.Email, "UQ__Employee__A9D10534C800C03A").IsUnique();
-
             entity.HasIndex(e => e.EmpNo, "UQ__Employee__AF2D66D2E1623B1B").IsUnique();
 
             entity.Property(e => e.AspNetUserId).HasMaxLength(450);
@@ -104,15 +97,13 @@ public partial class HrHubContext : DbContext
                 .HasConstraintName("FK_Employees_Designations");
         });
 
+        // --- Leave (Leaf) ---
         modelBuilder.Entity<Leaf>(entity =>
         {
             entity.HasKey(e => e.LeaveId).HasName("PK__Leaves__796DB959CB8CDFE6");
-
             entity.Property(e => e.Days).HasColumnType("decimal(5, 2)");
             entity.Property(e => e.Reason).HasMaxLength(200);
-            entity.Property(e => e.Status)
-                .HasMaxLength(20)
-                .HasDefaultValue("Pending");
+            entity.Property(e => e.Status).HasMaxLength(20).HasDefaultValue("Pending");
 
             entity.HasOne(d => d.ApprovedByEmployee).WithMany(p => p.LeafApprovedByEmployees)
                 .HasForeignKey(d => d.ApprovedByEmployeeId)
@@ -129,12 +120,39 @@ public partial class HrHubContext : DbContext
                 .HasConstraintName("FK_Leaves_Types");
         });
 
+        // --- LeaveType ---
         modelBuilder.Entity<LeaveType>(entity =>
         {
             entity.HasKey(e => e.LeaveTypeId).HasName("PK__LeaveTyp__43BE8F14E3C388E2");
-
             entity.Property(e => e.AnnualQuota).HasColumnType("decimal(5, 2)");
             entity.Property(e => e.Name).HasMaxLength(50);
+        });
+
+        // --- Promotion (NEW) ---
+        modelBuilder.Entity<Promotion>(entity =>
+        {
+            entity.HasKey(e => e.PromotionId);
+            entity.ToTable("Promotions");
+
+            entity.Property(e => e.Notes).HasMaxLength(200);
+
+            entity.HasOne(e => e.Employee)
+                  .WithMany() // or .WithMany(emp => emp.Promotions) if you add ICollection<Promotion> on Employee
+                  .HasForeignKey(e => e.EmployeeId)
+                  .OnDelete(DeleteBehavior.ClientSetNull)
+                  .HasConstraintName("FK_Promotions_Employees");
+
+            entity.HasOne(e => e.OldDesignation)
+                  .WithMany()
+                  .HasForeignKey(e => e.OldDesignationId)
+                  .OnDelete(DeleteBehavior.ClientSetNull)
+                  .HasConstraintName("FK_Promotions_Desig_Old");
+
+            entity.HasOne(e => e.NewDesignation)
+                  .WithMany()
+                  .HasForeignKey(e => e.NewDesignationId)
+                  .OnDelete(DeleteBehavior.ClientSetNull)
+                  .HasConstraintName("FK_Promotions_Desig_New");
         });
 
         OnModelCreatingPartial(modelBuilder);

--- a/HRHub/HRHub.Web/Data/Models/Promotion.cs
+++ b/HRHub/HRHub.Web/Data/Models/Promotion.cs
@@ -1,0 +1,17 @@
+﻿namespace HRHub.Web.Data.Models
+{
+    /// <summary>Promotion record: from old to new designation on a given effective date.</summary>
+    public partial class Promotion
+    {
+        public int PromotionId { get; set; }
+        public int EmployeeId { get; set; }
+        public int OldDesignationId { get; set; }
+        public int NewDesignationId { get; set; }
+        public DateOnly EffectiveDate { get; set; }
+        public string? Notes { get; set; }
+
+        public virtual Employee Employee { get; set; } = null!;
+        public virtual Designation OldDesignation { get; set; } = null!;
+        public virtual Designation NewDesignation { get; set; } = null!;
+    }
+}

--- a/HRHub/HRHub.Web/Data/Models/_promo_tmp/Designation.cs
+++ b/HRHub/HRHub.Web/Data/Models/_promo_tmp/Designation.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace HRHub.Web.Data.Models._promo_tmp;
+
+public partial class Designation
+{
+    public int DesignationId { get; set; }
+
+    public string Title { get; set; } = null!;
+
+    public int? Grade { get; set; }
+
+    public virtual ICollection<Employee> Employees { get; set; } = new List<Employee>();
+
+    public virtual ICollection<Promotion> PromotionNewDesignations { get; set; } = new List<Promotion>();
+
+    public virtual ICollection<Promotion> PromotionOldDesignations { get; set; } = new List<Promotion>();
+}

--- a/HRHub/HRHub.Web/Data/Models/_promo_tmp/Employee.cs
+++ b/HRHub/HRHub.Web/Data/Models/_promo_tmp/Employee.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace HRHub.Web.Data.Models._promo_tmp;
+
+public partial class Employee
+{
+    public int EmployeeId { get; set; }
+
+    public string EmpNo { get; set; } = null!;
+
+    public string FullName { get; set; } = null!;
+
+    public string Email { get; set; } = null!;
+
+    public DateOnly JoinDate { get; set; }
+
+    public int CompanyId { get; set; }
+
+    public int DepartmentId { get; set; }
+
+    public int DesignationId { get; set; }
+
+    public bool IsActive { get; set; }
+
+    public string? AspNetUserId { get; set; }
+
+    public virtual Designation Designation { get; set; } = null!;
+
+    public virtual ICollection<Promotion> Promotions { get; set; } = new List<Promotion>();
+}

--- a/HRHub/HRHub.Web/Data/Models/_promo_tmp/HrHubContext.cs
+++ b/HRHub/HRHub.Web/Data/Models/_promo_tmp/HrHubContext.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
+
+namespace HRHub.Web.Data.Models._promo_tmp;
+
+public partial class HrHubContext : DbContext
+{
+    public HrHubContext(DbContextOptions<HrHubContext> options)
+        : base(options)
+    {
+    }
+
+    public virtual DbSet<Designation> Designations { get; set; }
+
+    public virtual DbSet<Employee> Employees { get; set; }
+
+    public virtual DbSet<Promotion> Promotions { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Designation>(entity =>
+        {
+            entity.HasKey(e => e.DesignationId).HasName("PK__Designat__BABD60DE04591811");
+
+            entity.Property(e => e.Title).HasMaxLength(100);
+        });
+
+        modelBuilder.Entity<Employee>(entity =>
+        {
+            entity.HasKey(e => e.EmployeeId).HasName("PK__Employee__7AD04F11D413D973");
+
+            entity.HasIndex(e => e.Email, "UQ__Employee__A9D10534C800C03A").IsUnique();
+
+            entity.HasIndex(e => e.EmpNo, "UQ__Employee__AF2D66D2E1623B1B").IsUnique();
+
+            entity.Property(e => e.AspNetUserId).HasMaxLength(450);
+            entity.Property(e => e.Email).HasMaxLength(150);
+            entity.Property(e => e.EmpNo).HasMaxLength(20);
+            entity.Property(e => e.FullName).HasMaxLength(100);
+            entity.Property(e => e.IsActive).HasDefaultValue(true);
+
+            entity.HasOne(d => d.Designation).WithMany(p => p.Employees)
+                .HasForeignKey(d => d.DesignationId)
+                .OnDelete(DeleteBehavior.ClientSetNull)
+                .HasConstraintName("FK_Employees_Designations");
+        });
+
+        modelBuilder.Entity<Promotion>(entity =>
+        {
+            entity.HasKey(e => e.PromotionId).HasName("PK__Promotio__52C42FCF4E1365C1");
+
+            entity.Property(e => e.Notes).HasMaxLength(200);
+
+            entity.HasOne(d => d.Employee).WithMany(p => p.Promotions)
+                .HasForeignKey(d => d.EmployeeId)
+                .OnDelete(DeleteBehavior.ClientSetNull)
+                .HasConstraintName("FK_Promotions_Employees");
+
+            entity.HasOne(d => d.NewDesignation).WithMany(p => p.PromotionNewDesignations)
+                .HasForeignKey(d => d.NewDesignationId)
+                .OnDelete(DeleteBehavior.ClientSetNull)
+                .HasConstraintName("FK_Promotions_Desig_New");
+
+            entity.HasOne(d => d.OldDesignation).WithMany(p => p.PromotionOldDesignations)
+                .HasForeignKey(d => d.OldDesignationId)
+                .OnDelete(DeleteBehavior.ClientSetNull)
+                .HasConstraintName("FK_Promotions_Desig_Old");
+        });
+
+        OnModelCreatingPartial(modelBuilder);
+    }
+
+    partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
+}

--- a/HRHub/HRHub.Web/HRHub.Web.csproj
+++ b/HRHub/HRHub.Web/HRHub.Web.csproj
@@ -8,6 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Data\Models\_promo_tmp\**" />
+    <Content Remove="Data\Models\_promo_tmp\**" />
+    <EmbeddedResource Remove="Data\Models\_promo_tmp\**" />
+    <None Remove="Data\Models\_promo_tmp\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.19" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.19" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.19" />

--- a/HRHub/HRHub.Web/Program.cs
+++ b/HRHub/HRHub.Web/Program.cs
@@ -33,6 +33,9 @@ builder.Services
 
 builder.Services.AddControllersWithViews();
 builder.Services.AddScoped<LeaveService>();
+builder.Services.AddScoped<PromotionService>();
+
+
 
 
 var app = builder.Build();

--- a/HRHub/HRHub.Web/Services/PromotionService.cs
+++ b/HRHub/HRHub.Web/Services/PromotionService.cs
@@ -1,0 +1,48 @@
+﻿using HRHub.Web.Data.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace HRHub.Web.Services
+{
+    /// <summary>
+    /// Validates promotion rules:
+    /// - EffectiveDate >= JoinDate
+    /// - EffectiveDate > last promotion date (if exists)
+    /// - OldDesignationId must match current employee designation
+    /// - NewDesignationId must be different
+    /// </summary>
+    public class PromotionService
+    {
+        private readonly HrHubContext _db;
+        public PromotionService(HrHubContext db) => _db = db;
+
+        public async Task<(bool ok, string? error, DateOnly? last)> ValidateAsync(
+            int employeeId, int oldDesignationId, int newDesignationId, DateOnly effectiveDate)
+        {
+            var emp = await _db.Employees.AsNoTracking().FirstOrDefaultAsync(e => e.EmployeeId == employeeId);
+            if (emp == null) return (false, "Employee not found.", null);
+
+            if (oldDesignationId != emp.DesignationId)
+                return (false, "Old designation must match employee's current designation.", null);
+
+            if (newDesignationId == oldDesignationId)
+                return (false, "New designation cannot be the same as old designation.", null);
+
+            // JoinDate is DateOnly in your model
+            var join = emp.JoinDate;
+            if (effectiveDate < join)
+                return (false, "Effective date cannot be earlier than Join Date.", null);
+
+            // Last promotion date (if any)
+            var last = await _db.Promotions
+                .Where(p => p.EmployeeId == employeeId)
+                .OrderByDescending(p => p.EffectiveDate)
+                .Select(p => (DateOnly?)p.EffectiveDate)
+                .FirstOrDefaultAsync();
+
+            if (last.HasValue && effectiveDate <= last.Value)
+                return (false, $"Effective date must be later than last promotion date ({last.Value:yyyy-MM-dd}).", last);
+
+            return (true, null, last);
+        }
+    }
+}

--- a/HRHub/HRHub.Web/Views/Employees/Details.cshtml
+++ b/HRHub/HRHub.Web/Views/Employees/Details.cshtml
@@ -41,6 +41,9 @@
         </div>
         <div class="card-footer d-flex gap-2">
             <a asp-action="Edit" asp-route-id="@Model.EmployeeId" class="btn btn-primary">Edit</a>
+            <a asp-controller="Promotions" asp-action="Create" asp-route-employeeId="@Model.EmployeeId" class="btn btn-warning">Promote</a>
+            <a asp-controller="Promotions" asp-action="History" asp-route-id="@Model.EmployeeId" class="btn btn-outline-secondary">Promotion History</a>
+
             <a asp-action="Index" class="btn btn-outline-secondary">Back</a>
         </div>
     </div>

--- a/HRHub/HRHub.Web/Views/Promotions/Create.cshtml
+++ b/HRHub/HRHub.Web/Views/Promotions/Create.cshtml
@@ -1,0 +1,62 @@
+﻿@model HRHub.Web.Data.Models.Promotion
+@{
+    ViewData["Title"] = "Create Promotion";
+    var empName = ViewData["EmployeeName"] as string ?? "";
+    var oldTitle = ViewData["OldDesignationTitle"] as string ?? "";
+}
+<div class="container py-4">
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb mb-3">
+            <li class="breadcrumb-item"><a asp-controller="Employees" asp-action="Details" asp-route-id="@Model.EmployeeId">Employee</a></li>
+            <li class="breadcrumb-item active" aria-current="page">Promotion</li>
+        </ol>
+    </nav>
+
+    <div class="card card-shadow col-lg-7">
+        <div class="card-header"><strong>Promote: @empName</strong></div>
+        <div class="card-body">
+            <form asp-action="Create" method="post">
+                @Html.AntiForgeryToken()
+                <div asp-validation-summary="ModelOnly" class="alert alert-danger py-2"></div>
+
+                <input type="hidden" asp-for="EmployeeId" />
+                <div class="mb-3">
+                    <label class="form-label">Old designation</label>
+                    <input class="form-control" value="@oldTitle" disabled />
+                    <input type="hidden" asp-for="OldDesignationId" />
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="NewDesignationId" class="form-label"></label>
+                    <select asp-for="NewDesignationId" class="form-select" asp-items="ViewBag.NewDesignationId">
+                        <option value="">-- Select new designation --</option>
+                    </select>
+                    <span asp-validation-for="NewDesignationId" class="text-danger"></span>
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="EffectiveDate" class="form-label"></label>
+                    <input asp-for="EffectiveDate" class="form-control" type="date" />
+                    <span asp-validation-for="EffectiveDate" class="text-danger"></span>
+                </div>
+
+                <div class="mb-3">
+                    <label asp-for="Notes" class="form-label"></label>
+                    <textarea asp-for="Notes" class="form-control" rows="2"></textarea>
+                </div>
+
+                <div class="d-flex gap-2">
+                    <button type="submit" class="btn btn-primary">Save</button>
+                    <a asp-controller="Employees" asp-action="Details" asp-route-id="@Model.EmployeeId" class="btn btn-outline-secondary">Back</a>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    @{
+        await Html.RenderPartialAsync("_ValidationScriptsPartial");
+    }
+
+}

--- a/HRHub/HRHub.Web/Views/Promotions/History.cshtml
+++ b/HRHub/HRHub.Web/Views/Promotions/History.cshtml
@@ -1,0 +1,41 @@
+﻿@model IEnumerable<HRHub.Web.Data.Models.Promotion>
+@{
+    ViewData["Title"] = "Promotion History";
+    var empName = ViewData["EmployeeName"] as string ?? "";
+}
+<div class="container py-4">
+    <h3 class="mb-3">Promotion History — @empName</h3>
+
+    @if (!Model.Any())
+    {
+        <div class="alert alert-info">No promotion records found.</div>
+    }
+    else
+    {
+        <div class="card card-shadow">
+            <div class="table-responsive">
+                <table class="table table-striped table-hover align-middle mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th>Effective Date</th>
+                            <th>From</th>
+                            <th>To</th>
+                            <th>Notes</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var p in Model)
+                        {
+                            <tr>
+                                <td>@p.EffectiveDate.ToString("yyyy-MM-dd")</td>
+                                <td>@p.OldDesignation?.Title</td>
+                                <td>@p.NewDesignation?.Title</td>
+                                <td>@p.Notes</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    }
+</div>


### PR DESCRIPTION

- Admin: Create Promotion for a given employee
- Validation: EffectiveDate ≥ JoinDate; EffectiveDate > last promotion; old designation must match current; new != old
- Save in a transaction: insert Promotion + update Employee.DesignationId
- History view per employee (from/to/notes)
- Mappings: DbSet<Promotion> + fluent config added to HrHubContext
- DI: PromotionService registered

How to test
1) Employees → Details → Promote
2) Try invalid effective dates → see validation messages
3) Save a valid promotion → designation updated, success message
4) Open Promotion History → record visible
